### PR TITLE
Feat/label history

### DIFF
--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -15,14 +15,9 @@ import (
 
 const KeyCommands = "history.commands"
 
-func extractPodBaseName(pod *kubectl.Pod) string {
-	// TODO
-	return pod.Name
-}
-
 func StorePodProxy(projectId string, cluster *gcloud.Cluster, namespace string, pod *kubectl.Pod, localPort int, remotePort int) {
 
-	record := fmt.Sprintf("-project=%v -cluster=%v -namespace=%v -pod=%v -local_port=%v -proxy_type=pod", projectId, cluster.Name, namespace, extractPodBaseName(pod), localPort)
+	record := fmt.Sprintf("-project=%v -cluster=%v -namespace=%v -pod=%v -local_port=%v -proxy_type=pod", projectId, cluster.Name, namespace, pod.AppLabel, localPort)
 	store.Append(KeyCommands, record)
 }
 

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,15 +1,1 @@
 package history
-
-import (
-	"testing"
-
-	"github.com/AckeeCZ/goproxie/internal/kubectl"
-)
-
-func TestExtractPodBaseName(t *testing.T) {
-	t.Skip()
-	result := extractPodBaseName(&kubectl.Pod{Name: "dashed-app-name-598bf9b49d-9h2j7"})
-	if result != "dashed-app-name" {
-		t.Errorf("Expected dashed-app-name-598bf9b49d-9h2j7 to convert into dashed-app-name, got %v", result)
-	}
-}

--- a/internal/kubectl/cli.go
+++ b/internal/kubectl/cli.go
@@ -23,6 +23,7 @@ type Pod struct {
 	Name           string
 	Containers     []string
 	ContainerPorts []int
+	AppLabel       string
 }
 
 func NamespacesList() []string {
@@ -31,7 +32,7 @@ func NamespacesList() []string {
 
 func PodsList(namespace string) []*Pod {
 	out := runCommand(kubectlPath, "get", "pods", "--namespace", namespace, "--no-headers",
-		"-o=custom-columns=NAME:.metadata.name,CONTAINERS:spec.containers[*].name,PORTS:.spec.containers[*].ports[*].containerPort")
+		"-o=custom-columns=NAME:.metadata.name,CONTAINERS:spec.containers[*].name,PORTS:.spec.containers[*].ports[*].containerPort,LABELS=:.metadata.labels.app")
 	lines := strings.Split(out, "\n")
 	pods := []*Pod{}
 	for _, line := range lines {
@@ -46,7 +47,7 @@ func PodsList(namespace string) []*Pod {
 			port, _ := strconv.Atoi(portStr)
 			ports = append(ports, port)
 		}
-		pods = append(pods, &Pod{Name: tokens[0], Containers: containers, ContainerPorts: ports})
+		pods = append(pods, &Pod{Name: tokens[0], Containers: containers, ContainerPorts: ports, AppLabel: tokens[3]})
 	}
 	return pods
 }

--- a/internal/kubectl/cli_test.go
+++ b/internal/kubectl/cli_test.go
@@ -5,9 +5,9 @@ import "testing"
 // Exact command results
 
 // Should contain <none> ports and multi-ports
-var mockPodsList = `acme-rockets-v0.3.0-74bf544f8b-lzc5b                      event-exporter,prometheus-to-sd-exporter      <none>
-metrics-server-v0.3.3-6d96fcc55-2qtm8                       metrics-server,metrics-server-nanny           443
-traefik-ig-7646cb565d-9zxv6                                 traefik                                       80,443,8080,8081
+var mockPodsList = `acme-rockets-v0.3.0-74bf544f8b-lzc5b                      event-exporter,prometheus-to-sd-exporter      <none>           acme-rockets
+metrics-server-v0.3.3-6d96fcc55-2qtm8                       metrics-server,metrics-server-nanny           443           metrics-server
+traefik-ig-7646cb565d-9zxv6                                 traefik                                       80,443,8080,8081           traefik-ig
 `
 var mockNamespacesList = `acme-sro-development
 default
@@ -56,6 +56,7 @@ func TestPodsList(t *testing.T) {
 				"event-exporter",
 				"prometheus-to-sd-exporter",
 			},
+			AppLabel: "acme-rockets",
 		},
 		&Pod{
 			Name:           "metrics-server-v0.3.3-6d96fcc55-2qtm8",
@@ -64,6 +65,7 @@ func TestPodsList(t *testing.T) {
 				"metrics-server",
 				"metrics-server-nanny",
 			},
+			AppLabel: "metrics-server",
 		},
 		&Pod{
 			Name:           "traefik-ig-7646cb565d-9zxv6",
@@ -71,11 +73,15 @@ func TestPodsList(t *testing.T) {
 			Containers: []string{
 				"traefik",
 			},
+			AppLabel: "traefik-ig",
 		},
 	}
 	for i, expectedItem := range expectedItems {
 		resultItem := result[i]
 		if expectedItem.Name != resultItem.Name {
+			t.Errorf("Expected `%v` does not match result `%v`", expectedItem, resultItem)
+		}
+		if expectedItem.AppLabel != resultItem.AppLabel {
 			t.Errorf("Expected `%v` does not match result `%v`", expectedItem, resultItem)
 		}
 		for i, expectedPort := range expectedItem.ContainerPorts {


### PR DESCRIPTION
Purpose: save `-pod` to history without id suffix, e.g. `my-app` instead of `my-app-598bf9b49d-9h2j7` to make the history record work even though the id changed

- introduce `Pod.AppLabel` as `labels.app` from kubectl pod metadata
- use Pod.AppLabel for history `-pod` value
- update tests


