### PR TITLE
👷 Add github releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ script:
 before_deploy:
   - GOOS=linux go build -o=goproxie && zip goproxie-linux goproxie && rm goproxie
   - GOOS=darwin go build -o=goproxie && zip goproxie-mac goproxie && rm goproxie
-  - GOOS=windows go build -o=goproxie-win.exe
+  - GOOS=windows go build -o=goproxie.exe
 
 deploy:
   provider: releases
   api_key:
     secure: EVUQISZ1j+E4/v8894Ie5M//FGxEGXAoO4gW1J078W9UdZsUxq8mE19uuvaQuk7YwkJ881RmWR6ruiMeFABR1TNbQfoi4eQqvpTPicHHJoeXzx1W2aX1UlWSFXsnMKX8zwxz/aBM+uraxdV+WaZFFssNDZTLGnAYwKVk20I6s1QptsNgbAI6tocalcO1Urhp2PJ9+JTuJrQ0bo5k/dEIh1whHz0jvljcnUBC1uZa2QTQiECPu39Q+2NVOE2YddLTFbAwwMrOTaRJK/wLKmAD78r/vH0NgWjwTIKwDVSgPm6rGp2kbrnv/s5THgv80RpwGRWrx+8kLsJkEoaGcgWDYhDC3LjojjCWxsOq781C2jdKSh1eA5WnZxnV6TktELdb/abCcwIicaPZMpikfiQNTmSQuCqSY8TB3aWsyCS5JHGEV4ZAAJhTAcYgfioFtTQ5dk/iQLbbxluQf+2S1beWfLBIOw7ir7boxap+7DYBMRcgHW9nXE98sT8DsGBndOjLA+uJ6yW4t78HWFXegLABacXqIjc6nawbO3GVectGXdB/WejwFYVKcfRPpc+Mw0bP8wG0c7M0BCfuxBmULun+EJGZAjrp8DL9lrOVD7xwvV85UogoaOtk82gDApc0PyJLCPOMEKLSZwSILagtGMfQ7eJb3/QpDAWOfuH0QlsEqek=
   file: 
-    - goproxie-win.exe
+    - goproxie.exe
     - goproxie-mac.zip
     - goproxie-linux.zip
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 before_deploy:
   # Pass opts to Go compiler to set version from latest git tag at compile time
   # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
-  - LDFLAGS="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=`git describe --tags --abbrev=0`'"
+  - LDFLAGS="-X github.com/AckeeCZ/goproxie/internal/version.Version=`git describe --tags --abbrev=0`"
   - echo $LDFLAGS
   - GOOS=linux go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-linux goproxie && rm goproxie
   - GOOS=darwin go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-mac goproxie && rm goproxie

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,18 @@ script:
   - "$GOPATH/bin/goveralls -service=travis-ci"
 
 before_deploy:
-  - GOOS=linux go build -o=goproxie-linux
-  - GOOS=darwin go build -o=goproxie-mac
-  - GOOS=windows go build -o=goproxie-win
+  - GOOS=linux go build -o=goproxie && zip goproxie-linux goproxie && rm goproxie
+  - GOOS=darwin go build -o=goproxie && zip goproxie-mac goproxie && rm goproxie
+  - GOOS=windows go build -o=goproxie-win.exe
 
 deploy:
   provider: releases
   api_key:
     secure: EVUQISZ1j+E4/v8894Ie5M//FGxEGXAoO4gW1J078W9UdZsUxq8mE19uuvaQuk7YwkJ881RmWR6ruiMeFABR1TNbQfoi4eQqvpTPicHHJoeXzx1W2aX1UlWSFXsnMKX8zwxz/aBM+uraxdV+WaZFFssNDZTLGnAYwKVk20I6s1QptsNgbAI6tocalcO1Urhp2PJ9+JTuJrQ0bo5k/dEIh1whHz0jvljcnUBC1uZa2QTQiECPu39Q+2NVOE2YddLTFbAwwMrOTaRJK/wLKmAD78r/vH0NgWjwTIKwDVSgPm6rGp2kbrnv/s5THgv80RpwGRWrx+8kLsJkEoaGcgWDYhDC3LjojjCWxsOq781C2jdKSh1eA5WnZxnV6TktELdb/abCcwIicaPZMpikfiQNTmSQuCqSY8TB3aWsyCS5JHGEV4ZAAJhTAcYgfioFtTQ5dk/iQLbbxluQf+2S1beWfLBIOw7ir7boxap+7DYBMRcgHW9nXE98sT8DsGBndOjLA+uJ6yW4t78HWFXegLABacXqIjc6nawbO3GVectGXdB/WejwFYVKcfRPpc+Mw0bP8wG0c7M0BCfuxBmULun+EJGZAjrp8DL9lrOVD7xwvV85UogoaOtk82gDApc0PyJLCPOMEKLSZwSILagtGMfQ7eJb3/QpDAWOfuH0QlsEqek=
   file: 
-    - goproxie-win
-    - goproxie-mac
-    - goproxie-linux
+    - goproxie-win.exe
+    - goproxie-mac.zip
+    - goproxie-linux.zip
   on:
     # TODO Remove when tested
     branch: feat/travis-deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
-  - $GOPATH/bin/goveralls -service=travis-ci
+  - "$GOPATH/bin/goveralls -service=travis-ci"
 
 before_deploy:
   - GOOS=linux go build -o=goproxie-linux
@@ -16,7 +16,8 @@ before_deploy:
 
 deploy:
   provider: releases
-  api_key: "GITHUB OAUTH TOKEN"
+  api_key:
+    secure: EVUQISZ1j+E4/v8894Ie5M//FGxEGXAoO4gW1J078W9UdZsUxq8mE19uuvaQuk7YwkJ881RmWR6ruiMeFABR1TNbQfoi4eQqvpTPicHHJoeXzx1W2aX1UlWSFXsnMKX8zwxz/aBM+uraxdV+WaZFFssNDZTLGnAYwKVk20I6s1QptsNgbAI6tocalcO1Urhp2PJ9+JTuJrQ0bo5k/dEIh1whHz0jvljcnUBC1uZa2QTQiECPu39Q+2NVOE2YddLTFbAwwMrOTaRJK/wLKmAD78r/vH0NgWjwTIKwDVSgPm6rGp2kbrnv/s5THgv80RpwGRWrx+8kLsJkEoaGcgWDYhDC3LjojjCWxsOq781C2jdKSh1eA5WnZxnV6TktELdb/abCcwIicaPZMpikfiQNTmSQuCqSY8TB3aWsyCS5JHGEV4ZAAJhTAcYgfioFtTQ5dk/iQLbbxluQf+2S1beWfLBIOw7ir7boxap+7DYBMRcgHW9nXE98sT8DsGBndOjLA+uJ6yW4t78HWFXegLABacXqIjc6nawbO3GVectGXdB/WejwFYVKcfRPpc+Mw0bP8wG0c7M0BCfuxBmULun+EJGZAjrp8DL9lrOVD7xwvV85UogoaOtk82gDApc0PyJLCPOMEKLSZwSILagtGMfQ7eJb3/QpDAWOfuH0QlsEqek=
   file: 
     - goproxie-win
     - goproxie-mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,4 @@ deploy:
   overwrite: true
   # TODO Uncomment when deploys are stable
   draft: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_deploy:
   # Pass opts to Go compiler to set version from latest git tag at compile time
   # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
   - LDFLAGS="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=`git describe --tags --abbrev=0`'"
+  - echo $LDFLAGS
   - GOOS=linux go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-linux goproxie && rm goproxie
   - GOOS=darwin go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-mac goproxie && rm goproxie
   - GOOS=windows go build -ldflags=$LDFLAGS -o=goproxie.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ script:
   - "$GOPATH/bin/goveralls -service=travis-ci"
 
 before_deploy:
-  - GOOS=linux go build -o=goproxie && zip goproxie-linux goproxie && rm goproxie
-  - GOOS=darwin go build -o=goproxie && zip goproxie-mac goproxie && rm goproxie
-  - GOOS=windows go build -o=goproxie.exe
+  # Pass opts to Go compiler to set version from latest git tag at compile time
+  # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
+  - LDFLAGS="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=`git describe --tags --abbrev=0`'"
+  - GOOS=linux go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-linux goproxie && rm goproxie
+  - GOOS=darwin go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-mac goproxie && rm goproxie
+  - GOOS=windows go build -ldflags=$LDFLAGS -o=goproxie.exe
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,18 @@ script:
 before_deploy:
   # Pass opts to Go compiler to set version from latest git tag at compile time
   # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
-  - GOOS=linux go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie && zip goproxie-linux goproxie && rm goproxie
-  - GOOS=darwin go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie && zip goproxie-mac goproxie && rm goproxie
-  - GOOS=windows go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie.exe
+  - GOOS=linux go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie && zip goproxie-linux-$TRAVIS_TAG.zip goproxie && rm goproxie
+  - GOOS=darwin go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie && zip goproxie-mac-$TRAVIS_TAG.zip goproxie && rm goproxie
+  - GOOS=windows go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie.exe  && zip goproxie-win-$TRAVIS_TAG.zip goproxie.exe && rm goproxie.exe
 
 deploy:
   provider: releases
   api_key:
     secure: EVUQISZ1j+E4/v8894Ie5M//FGxEGXAoO4gW1J078W9UdZsUxq8mE19uuvaQuk7YwkJ881RmWR6ruiMeFABR1TNbQfoi4eQqvpTPicHHJoeXzx1W2aX1UlWSFXsnMKX8zwxz/aBM+uraxdV+WaZFFssNDZTLGnAYwKVk20I6s1QptsNgbAI6tocalcO1Urhp2PJ9+JTuJrQ0bo5k/dEIh1whHz0jvljcnUBC1uZa2QTQiECPu39Q+2NVOE2YddLTFbAwwMrOTaRJK/wLKmAD78r/vH0NgWjwTIKwDVSgPm6rGp2kbrnv/s5THgv80RpwGRWrx+8kLsJkEoaGcgWDYhDC3LjojjCWxsOq781C2jdKSh1eA5WnZxnV6TktELdb/abCcwIicaPZMpikfiQNTmSQuCqSY8TB3aWsyCS5JHGEV4ZAAJhTAcYgfioFtTQ5dk/iQLbbxluQf+2S1beWfLBIOw7ir7boxap+7DYBMRcgHW9nXE98sT8DsGBndOjLA+uJ6yW4t78HWFXegLABacXqIjc6nawbO3GVectGXdB/WejwFYVKcfRPpc+Mw0bP8wG0c7M0BCfuxBmULun+EJGZAjrp8DL9lrOVD7xwvV85UogoaOtk82gDApc0PyJLCPOMEKLSZwSILagtGMfQ7eJb3/QpDAWOfuH0QlsEqek=
   file: 
-    - goproxie.exe
-    - goproxie-mac.zip
-    - goproxie-linux.zip
+    - goproxie-win-$TRAVIS_TAG.zip
+    - goproxie-mac-$TRAVIS_TAG.zip
+    - goproxie-linux-$TRAVIS_TAG.zip
   on:
     tags: true
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - "$GOPATH/bin/goveralls -service=travis-ci"
 
 before_deploy:
+  # Get latest git tag
   - LATEST_GIT_TAG=`git describe --tags --abbrev=0`
   # Pass opts to Go compiler to set version from latest git tag at compile time
   # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
@@ -26,12 +27,6 @@ deploy:
     - goproxie-mac.zip
     - goproxie-linux.zip
   on:
-    # TODO Remove when tested
-    branch: feat/travis-deploy
-    # TODO Uncomment when tested
-    # tags: true
+    tags: true
   skip_cleanup: true
-  overwrite: true
-  # TODO Uncomment when deploys are stable
-  draft: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ script:
   - "$GOPATH/bin/goveralls -service=travis-ci"
 
 before_deploy:
+  - LATEST_GIT_TAG=`git describe --tags --abbrev=0`
   # Pass opts to Go compiler to set version from latest git tag at compile time
   # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
-  - LDFLAGS="-X github.com/AckeeCZ/goproxie/internal/version.Version=`git describe --tags --abbrev=0`"
-  - echo $LDFLAGS
-  - GOOS=linux go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-linux goproxie && rm goproxie
-  - GOOS=darwin go build -ldflags=$LDFLAGS -o=goproxie && zip goproxie-mac goproxie && rm goproxie
-  - GOOS=windows go build -ldflags=$LDFLAGS -o=goproxie.exe
+  - GOOS=linux go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$LATEST_GIT_TAG'" -o=goproxie && zip goproxie-linux goproxie && rm goproxie
+  - GOOS=darwin go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$LATEST_GIT_TAG'" -o=goproxie && zip goproxie-mac goproxie && rm goproxie
+  - GOOS=windows go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$LATEST_GIT_TAG'" -o=goproxie.exe
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,22 @@ before_install:
 
 script:
   - $GOPATH/bin/goveralls -service=travis-ci
+
+before_deploy:
+  - GOOS=linux go build -o=goproxie-linux
+  - GOOS=darwin go build -o=goproxie-mac
+  - GOOS=windows go build -o=goproxie-win
+
+deploy:
+  provider: releases
+  api_key: "GITHUB OAUTH TOKEN"
+  file: 
+    - goproxie-win
+    - goproxie-mac
+    - goproxie-linux
+  # skip_cleanup: true
+  overwrite: true
+  # TODO Uncomment when deploys are stable
+  draft: true
+  # on:
+  #   tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ script:
   - "$GOPATH/bin/goveralls -service=travis-ci"
 
 before_deploy:
-  # Get latest git tag
-  - LATEST_GIT_TAG=`git describe --tags --abbrev=0`
   # Pass opts to Go compiler to set version from latest git tag at compile time
   # See https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications
-  - GOOS=linux go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$LATEST_GIT_TAG'" -o=goproxie && zip goproxie-linux goproxie && rm goproxie
-  - GOOS=darwin go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$LATEST_GIT_TAG'" -o=goproxie && zip goproxie-mac goproxie && rm goproxie
-  - GOOS=windows go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$LATEST_GIT_TAG'" -o=goproxie.exe
+  - GOOS=linux go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie && zip goproxie-linux goproxie && rm goproxie
+  - GOOS=darwin go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie && zip goproxie-mac goproxie && rm goproxie
+  - GOOS=windows go build -ldflags="-X 'github.com/AckeeCZ/goproxie/internal/version.Version=$TRAVIS_TAG'" -o=goproxie.exe
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,12 @@ deploy:
     - goproxie-win
     - goproxie-mac
     - goproxie-linux
+  on:
+    # TODO Remove when tested
+    branch: feat/travis-deploy
+    # TODO Uncomment when tested
+    # tags: true
   # skip_cleanup: true
   overwrite: true
   # TODO Uncomment when deploys are stable
   draft: true
-  # on:
-  #   tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ deploy:
     branch: feat/travis-deploy
     # TODO Uncomment when tested
     # tags: true
-  # skip_cleanup: true
+  skip_cleanup: true
   overwrite: true
   # TODO Uncomment when deploys are stable
   draft: true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 ## User manual
 
+- `goproxie version` to print the version
 - Use default `goproxie` to start interactive wizard
 - Use `goproxie history` to pick a used proxy settings
 - Use `goproxie -project=... -cluster=...` for non-interactive mode, see `--help` for all the options available
@@ -33,3 +34,9 @@ See coverage
 ```sh
 go test ./... -v -coverprofile=coverage.out && go tool cover -html=coverage.out
 ```
+
+## Release a new version
+
+- add a new git version tag , prefixed with `v`, e.g. `v12.34.56`
+- set it based on last tag and respect [Semantic Versioning](https://semver.org/)
+- goproxie will incorporate this tag in it's `version` command during release step when tags are pushed

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var Version = "N/A"
+
+func Get() string {
+	return Version
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AckeeCZ/goproxie/internal/history"
 	"github.com/AckeeCZ/goproxie/internal/kubectl"
 	"github.com/AckeeCZ/goproxie/internal/store"
+	"github.com/AckeeCZ/goproxie/internal/version"
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/briandowns/spinner"
 )
@@ -256,6 +257,11 @@ func readArguments() {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		fmt.Println(version.Get())
+		return
+	}
+
 	readArguments()
 	store.Initialize()
 	if len(os.Args) > 1 && os.Args[1] == "history" {


### PR DESCRIPTION
- added CI deploy step to GitHub releases
   - release contains binaries for windows, macosx and linux (using GOOS=linux|windows|darwin), resulting in
   - goproxie.exe
   - goproxie-mac.zip/goproxie
   - goproxie-linux.zip/goproxie
   - release happens on tags only
- added `version` command
   - version is set automagically during build step based on latest git tag (found as `git describe --tags --abbrev=0`)
   - injected to app using [`ldflags`](https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications)
- added release steps to readme
   - you have to manually set the new git tag based on the last one, I havent found any equivalent to  [npm`s version](https://docs.npmjs.com/cli/version) (which upon calling automatically increases version in package.json and creates a new git tag)
- added version command to readme