### PR TITLE
Fix/goreport

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/internal/gcloud/cli.go
+++ b/internal/gcloud/cli.go
@@ -10,19 +10,23 @@ var gcloudPath = "gcloud"
 
 var runCommand = util.RunCommand
 
+// SetGcloudPath sets the executable path to gcloud bin.
 func SetGcloudPath(path string) {
 	gcloudPath = path
 }
 
+// ProjectsList returns the list of google cloud projects
 func ProjectsList() []string {
 	return strings.Fields(runCommand(gcloudPath, "projects", "list", "--format", "value(projectId)"))
 }
 
+// Cluster structure
 type Cluster struct {
 	Name     string
 	Location string
 }
 
+//ContainerClustersList returns the list of GCP clusters
 func ContainerClustersList(projectId string) []*Cluster {
 	out := runCommand(gcloudPath, "container", "clusters", "list", "--format", "value(name, location)", "--project", projectId)
 	lines := strings.Split(out, "\n")
@@ -37,6 +41,7 @@ func ContainerClustersList(projectId string) []*Cluster {
 	// return Cluster{name: results[0], location: results[1]}
 }
 
+// GetClusterCredentials gets credentials for the given GCP cluster
 func GetClusterCredentials(projectID string, cluster *Cluster) {
 	util.RunSilentCommand(gcloudPath, "container", "clusters", "get-credentials", cluster.Name, "--project", projectID, "--zone", cluster.Location)
 }

--- a/internal/gcloud/cli.go
+++ b/internal/gcloud/cli.go
@@ -27,8 +27,8 @@ type Cluster struct {
 }
 
 //ContainerClustersList returns the list of GCP clusters
-func ContainerClustersList(projectId string) []*Cluster {
-	out := runCommand(gcloudPath, "container", "clusters", "list", "--format", "value(name, location)", "--project", projectId)
+func ContainerClustersList(projectID string) []*Cluster {
+	out := runCommand(gcloudPath, "container", "clusters", "list", "--format", "value(name, location)", "--project", projectID)
 	lines := strings.Split(out, "\n")
 	clusters := []*Cluster{}
 	for _, line := range lines {

--- a/internal/gcloud/cli_test.go
+++ b/internal/gcloud/cli_test.go
@@ -46,7 +46,7 @@ func TestContainerClustersList(t *testing.T) {
 	defer unmock()
 	result := ContainerClustersList("anyproject")
 	expectedItems := []*Cluster{
-		&Cluster{
+		{
 			Name:     "production",
 			Location: "europe-west1-d",
 		},

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -18,9 +18,9 @@ const KeyCommands = "history.commands"
 
 // StorePodProxy appends the given run configuration to history commands
 // in a form of non-interactive goproxie arguments.
-func StorePodProxy(projectId string, cluster *gcloud.Cluster, namespace string, pod *kubectl.Pod, localPort int, remotePort int) {
+func StorePodProxy(projectID string, cluster *gcloud.Cluster, namespace string, pod *kubectl.Pod, localPort int, remotePort int) {
 
-	record := fmt.Sprintf("-project=%v -cluster=%v -namespace=%v -pod=%v -local_port=%v -proxy_type=pod", projectId, cluster.Name, namespace, pod.AppLabel, localPort)
+	record := fmt.Sprintf("-project=%v -cluster=%v -namespace=%v -pod=%v -local_port=%v -proxy_type=pod", projectID, cluster.Name, namespace, pod.AppLabel, localPort)
 	store.Append(KeyCommands, record)
 }
 

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -13,14 +13,19 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 )
 
+// KeyCommands defines the configration key
 const KeyCommands = "history.commands"
 
+// StorePodProxy appends the given run configuration to history commands
+// in a form of non-interactive goproxie arguments.
 func StorePodProxy(projectId string, cluster *gcloud.Cluster, namespace string, pod *kubectl.Pod, localPort int, remotePort int) {
 
 	record := fmt.Sprintf("-project=%v -cluster=%v -namespace=%v -pod=%v -local_port=%v -proxy_type=pod", projectId, cluster.Name, namespace, pod.AppLabel, localPort)
 	store.Append(KeyCommands, record)
 }
 
+// Browse lets user choose from stored commands.
+// Goproxie is executed with given arguments.
 func Browse() {
 	storedCommands := store.Get(KeyCommands)
 	commands := []string{}

--- a/internal/kubectl/cli.go
+++ b/internal/kubectl/cli.go
@@ -15,10 +15,12 @@ var kubectlPath = "kubectl"
 
 var runCommand = util.RunCommand
 
+// SetKubectlPath sets the executable path to kubectl bin.
 func SetKubectlPath(path string) {
 	kubectlPath = path
 }
 
+// Pod structure
 type Pod struct {
 	Name           string
 	Containers     []string
@@ -26,10 +28,12 @@ type Pod struct {
 	AppLabel       string
 }
 
+// NamespacesList returns the list of k8s namespaces
 func NamespacesList() []string {
 	return strings.Fields(runCommand(kubectlPath, "get", "namespaces", "-o=custom-columns=NAME:.metadata.name", "--no-headers"))
 }
 
+// PodsList returns the list of k8s pods from the given namespace
 func PodsList(namespace string) []*Pod {
 	out := runCommand(kubectlPath, "get", "pods", "--namespace", namespace, "--no-headers",
 		"-o=custom-columns=NAME:.metadata.name,CONTAINERS:spec.containers[*].name,PORTS:.spec.containers[*].ports[*].containerPort,LABELS=:.metadata.labels.app")
@@ -52,6 +56,8 @@ func PodsList(namespace string) []*Pod {
 	return pods
 }
 
+// PortForward executes kubectl's 'port-forward'.
+// Local port is bound to 0.0.0.0. via '--address'.
 func PortForward(podId string, localPort int, remotePort int, namespace string) {
 	cmd := exec.Command(kubectlPath, "port-forward", podId, fmt.Sprintf("%v:%v", localPort, remotePort), "--namespace", namespace, "--address", "0.0.0.0")
 	cmd.Stderr = os.Stderr

--- a/internal/kubectl/cli.go
+++ b/internal/kubectl/cli.go
@@ -58,8 +58,8 @@ func PodsList(namespace string) []*Pod {
 
 // PortForward executes kubectl's 'port-forward'.
 // Local port is bound to 0.0.0.0. via '--address'.
-func PortForward(podId string, localPort int, remotePort int, namespace string) {
-	cmd := exec.Command(kubectlPath, "port-forward", podId, fmt.Sprintf("%v:%v", localPort, remotePort), "--namespace", namespace, "--address", "0.0.0.0")
+func PortForward(podID string, localPort int, remotePort int, namespace string) {
+	cmd := exec.Command(kubectlPath, "port-forward", podID, fmt.Sprintf("%v:%v", localPort, remotePort), "--namespace", namespace, "--address", "0.0.0.0")
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	err := cmd.Run()

--- a/internal/kubectl/cli_test.go
+++ b/internal/kubectl/cli_test.go
@@ -48,7 +48,7 @@ func TestPodsList(t *testing.T) {
 	defer unmock()
 	result := PodsList("anynamespace")
 	expectedItems := []*Pod{
-		&Pod{
+		{
 			Name: "acme-rockets-v0.3.0-74bf544f8b-lzc5b",
 			// TODO Is it OK to have [0] for <none>? Because it does that now.
 			ContainerPorts: []int{0},
@@ -58,7 +58,7 @@ func TestPodsList(t *testing.T) {
 			},
 			AppLabel: "acme-rockets",
 		},
-		&Pod{
+		{
 			Name:           "metrics-server-v0.3.3-6d96fcc55-2qtm8",
 			ContainerPorts: []int{443},
 			Containers: []string{
@@ -67,7 +67,7 @@ func TestPodsList(t *testing.T) {
 			},
 			AppLabel: "metrics-server",
 		},
-		&Pod{
+		{
 			Name:           "traefik-ig-7646cb565d-9zxv6",
 			ContainerPorts: []int{80, 443, 8080, 8081},
 			Containers: []string{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,8 +9,11 @@ import (
 	"github.com/spf13/viper"
 )
 
+// MaxAppendLength defines max stored commands threshold
 const MaxAppendLength = 100
 
+// Initialize reads the configuration from config file.
+// File is created if not present.
 func Initialize() {
 	user, err := user.Current()
 	if err != nil {
@@ -44,15 +47,21 @@ func Initialize() {
 	viper.ReadInConfig()
 }
 
+// Set configuration key-value pair.
+// Value is immediately saved to config file.
 func Set(key string, value interface{}) error {
 	viper.Set(key, value)
 	return viper.WriteConfig()
 }
 
+// Get configuration value for key.
 func Get(key string) interface{} {
 	return viper.Get(key)
 }
 
+// Append value to given key. Expects the value to be an array or not set.
+// Acts as FIFO if length should be greater than MaxAppendLength, the first value
+// appended is the first to go.
 func Append(key string, value interface{}) error {
 	currentValue := []interface{}{}
 	if viper.IsSet(key) {

--- a/internal/util/commands.go
+++ b/internal/util/commands.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 )
 
+// RunCommand executes given command with args, automatically exits program on error.
 func RunCommand(command string, args ...string) string {
 	cmd := exec.Command(command, args...)
 	cmd.Stderr = os.Stderr
@@ -16,6 +17,7 @@ func RunCommand(command string, args ...string) string {
 	return string(out)
 }
 
+// RunSilentCommand is same as RunCommand but does not forward stderr.
 // TODO: Remove and refactor RunCommand to print stderr only when err happens
 // due to gcloud printing to stderr it's debug messages
 func RunSilentCommand(command string, args ...string) string {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,7 +1,9 @@
 package version
 
+// Version of the program. Is injected via ldflags during compilation with latest tag value.
 var Version = "N/A"
 
+// Get returns program version
 func Get() string {
 	return Version
 }

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func loadingStop() {
 	loading.Suffix = ""
 }
 
+// Flags - goproxie program options
 type Flags struct {
 	project    *string
 	proxyType  *string

--- a/main_test.go
+++ b/main_test.go
@@ -121,10 +121,10 @@ func TestHappyPath(t *testing.T) {
 	unmockAll := mockAll(
 		[]string{"project-1"},
 		[]*kubectl.Pod{
-			&kubectl.Pod{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
+			{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
 		},
 		[]*gcloud.Cluster{
-			&gcloud.Cluster{Name: "cluster-1", Location: "location-1"},
+			{Name: "cluster-1", Location: "location-1"},
 		},
 		"POD",
 		[]string{"namespace-1"},
@@ -154,10 +154,10 @@ func ExampleNoProjects() {
 	unmockAll := mockAll(
 		[]string{},
 		[]*kubectl.Pod{
-			&kubectl.Pod{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
+			{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
 		},
 		[]*gcloud.Cluster{
-			&gcloud.Cluster{Name: "cluster-1", Location: "location-1"},
+			{Name: "cluster-1", Location: "location-1"},
 		},
 		"POD",
 		[]string{"namespace-1"},
@@ -173,7 +173,7 @@ func ExampleNoClusters() {
 	unmockAll := mockAll(
 		[]string{"project-1"},
 		[]*kubectl.Pod{
-			&kubectl.Pod{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
+			{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
 		},
 		[]*gcloud.Cluster{},
 		"POD",
@@ -192,10 +192,10 @@ func ExampleNoNamespaces() {
 	unmockAll := mockAll(
 		[]string{"project-1"},
 		[]*kubectl.Pod{
-			&kubectl.Pod{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
+			{Name: "pod-1", ContainerPorts: []int{1}, Containers: []string{"container-1"}},
 		},
 		[]*gcloud.Cluster{
-			&gcloud.Cluster{Name: "cluster-1", Location: "location-1"},
+			{Name: "cluster-1", Location: "location-1"},
 		},
 		"POD",
 		[]string{},
@@ -215,7 +215,7 @@ func ExampleNoPods() {
 		[]string{"project-1"},
 		[]*kubectl.Pod{},
 		[]*gcloud.Cluster{
-			&gcloud.Cluster{Name: "cluster-1", Location: "location-1"},
+			{Name: "cluster-1", Location: "location-1"},
 		},
 		"POD",
 		[]string{"namespace-1"},


### PR DESCRIPTION
addresses [these](https://goreportcard.com/report/github.com/AckeeCZ/goproxie) errors reported by goreportcard
- adds MIT license file
- adds comments to exported members (["Comments should begin with the name of the thing being described and end in a period"](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) - this really ***** me off :D)
- formats files with gofmt (VS Code has option that can be passed to a formatter - the suggested `-s`, but it didnt work for me, had to run `gofmt -w -s .` manually)