### PR TITLE
Feat/30 projectless cloudsql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Option for connecting to Cloud SQL instance with instance name only
+
 ### Fixed
 - Invalid cloud SQL history records
-
 
 ## [1.1.0] - 2020-06-15
 ### Added

--- a/main.go
+++ b/main.go
@@ -140,6 +140,9 @@ func promptSelection(sel selectField) interface{} {
 }
 
 func readProjectID() (projectID string) {
+	if isBlindCloudSQLConnection() {
+		return ""
+	}
 	// Cannot return directly, I have to accept both return values to avoid crash 🤷
 	// https://gist.github.com/smoliji/f72fe94b028125a22efa53a430ba007a
 	projectID, _ = promptSelection(selectField{
@@ -219,6 +222,11 @@ func readPod(namespace string) (pod *kubectl.Pod) {
 }
 
 func readCloudSQLInstance(projectID string) (instance sqlproxy.CloudSQLInstance) {
+	// Allow to connect using only the instance connection name
+	// when user does not have `gcloud projects list` projec rights
+	if isBlindCloudSQLConnection() {
+		return sqlproxy.CloudSQLInstance{ConnectionName: *flags.sqlInstance, Type: sqlproxy.TypeUnknown}
+	}
 	instance, _ = promptSelection(selectField{
 		titleLoading: "Cloud SQL instances",
 		titleChoose:  "Cloud SQL instance",
@@ -300,10 +308,14 @@ func readArguments() {
 	flags.localPort = flag.String("local_port", "", "Auto Local port pick")
 	flags.remotePort = flag.String("remote_port", "", "Auto Remote port pick")
 	flags.noSave = flag.Bool("no-save", false, "Don't save invocation to history")
-	flags.sqlInstance = flag.String("sql_instance", "", "Cloud SQL Instance in form project:region:instance-name")
+	flags.sqlInstance = flag.String("sql_instance", "", "Cloud SQL Instance in form project:region:instance-name. Can be used if you dont have permissions to list the GCP project.")
 	flag.Parse()
 	gcloud.SetGcloudPath(*gcloudPath)
 	kubectl.SetKubectlPath(*kubectlPath)
+}
+
+func isBlindCloudSQLConnection() bool {
+	return *flags.sqlInstance != "" && *flags.project == ""
 }
 
 func main() {
@@ -319,7 +331,7 @@ func main() {
 		return
 	}
 	projectID := readProjectID()
-	if projectID == "" {
+	if projectID == "" && !isBlindCloudSQLConnection() {
 		fmt.Println("Could not find any GCP Projects")
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func readPod(namespace string) (pod *kubectl.Pod) {
 
 func readCloudSQLInstance(projectID string) (instance sqlproxy.CloudSQLInstance) {
 	// Allow to connect using only the instance connection name
-	// when user does not have `gcloud projects list` projec rights
+	// when user does not have `gcloud projects list` project rights
 	if isBlindCloudSQLConnection() {
 		return sqlproxy.CloudSQLInstance{ConnectionName: *flags.sqlInstance, Type: sqlproxy.TypeUnknown}
 	}


### PR DESCRIPTION
I hope I was able to do it with existing sql_instance switch. If it is defined, there is no need to ask for the project - instance connection name is sufficient for Google cloud to know which project it is.

Fixes: https://github.com/AckeeCZ/goproxie/issues/30