### PR TITLE
✨ Remove history duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed 
+- History does not contain duplicate items
 
 ## [1.2.0] - 2020-06-16
 ### Added


### PR DESCRIPTION
Everytime on start, check for duplicates in history and remove them, keep the ordering.

Fixes: #34