### PR TITLE
Fix/36 missing history pod name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed 
+- History does not contain duplicate items
 
 ## [1.2.0] - 2020-06-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 
 - History does not contain duplicate items
 
+### Fixed
+- Invalid history records with pod name `<none>`
+
 ## [1.2.0] - 2020-06-16
 ### Added
 - Option for connecting to Cloud SQL instance with instance name only

--- a/internal/kubectl/cli.go
+++ b/internal/kubectl/cli.go
@@ -53,7 +53,13 @@ func PodsList(namespace string) []*Pod {
 				ports = append(ports, port)
 			}
 		}
-		pods = append(pods, &Pod{Name: tokens[0], Containers: containers, ContainerPorts: ports, AppLabel: tokens[3]})
+		name := tokens[0]
+		appLabel := tokens[3]
+		// `<none>` is empty serialization value from kubectl
+		if appLabel == "<none>" {
+			appLabel = name
+		}
+		pods = append(pods, &Pod{Name: name, Containers: containers, ContainerPorts: ports, AppLabel: appLabel})
 	}
 	return pods
 }

--- a/internal/kubectl/cli_test.go
+++ b/internal/kubectl/cli_test.go
@@ -6,6 +6,7 @@ import "testing"
 
 // Should contain <none> ports and multi-ports
 var mockPodsList = `acme-rockets-v0.3.0-74bf544f8b-lzc5b                      event-exporter,prometheus-to-sd-exporter      <none>           acme-rockets
+acme-finances-0                                           event-exporter                                <none>           <none>
 metrics-server-v0.3.3-6d96fcc55-2qtm8                       metrics-server,metrics-server-nanny           443           metrics-server
 traefik-ig-7646cb565d-9zxv6                                 traefik                                       80,443,8080,8081           traefik-ig
 `
@@ -49,13 +50,21 @@ func TestPodsList(t *testing.T) {
 	result := PodsList("anynamespace")
 	expectedItems := []*Pod{
 		{
-			Name: "acme-rockets-v0.3.0-74bf544f8b-lzc5b",
+			Name:           "acme-rockets-v0.3.0-74bf544f8b-lzc5b",
 			ContainerPorts: []int{},
 			Containers: []string{
 				"event-exporter",
 				"prometheus-to-sd-exporter",
 			},
 			AppLabel: "acme-rockets",
+		},
+		{
+			Name:           "acme-finances-0",
+			ContainerPorts: []int{},
+			Containers: []string{
+				"event-exporter",
+			},
+			AppLabel: "acme-finances-0",
 		},
 		{
 			Name:           "metrics-server-v0.3.3-6d96fcc55-2qtm8",


### PR DESCRIPTION
Blocked by https://github.com/AckeeCZ/goproxie/pull/35

- some pod's `.metadata.labels.app` were empty
- `.metadata.labels.app` are used for history as `-pod` to ignore variable pod names as `acme-rockets-v0.3.0-74bf544f8b-lzc5b` and use `acme-rockets-v0.3.0` instead
- solution is to use `Name` as the default value for pod's `AppLabel`

Fixes: #36 