### PR TITLE
📝  Add link to executables to installation manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add link to executables to installation manual
 
 ## [1.3.0] - 2020-07-21
 ### Changed 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,18 @@
 ```
 gcloud auth login
 ```
+```
+gcloud auth application-default login
+```
 3. Get goproxie:
-```
-go get -u github.com/AckeeCZ/goproxie
-```
-This will download the source and compile the executable `$GOPATH/bin/goproxie`. Make sure `$GOPATH/bin` is in your `$PATH`.
+
+    a) Build from source
+    ```
+    go get -u github.com/AckeeCZ/goproxie
+    ```
+    This will download the source and compile the executable `$GOPATH/bin/goproxie`. Make sure `$GOPATH/bin` is in your `$PATH`.
+
+    b) Download latest executable for macOS, Windows, Linux [here](https://github.com/AckeeCZ/goproxie/releases)
 
 ## Test
 


### PR DESCRIPTION
1️⃣ people ignored release page and just read readme.

- add second option to get goproxie - add links to releases

2️⃣ even though [docs](https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login) says `This command has no effect on the user account(s) set up by the gcloud auth login command.` - it is a lie! Cloud sql doesn't work and crashes on


> google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.

🤷


Fixes: #38