### PR TITLE
🐛 Fix always selecting sql proxy type

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ var readProxyType = func() ProxyType {
 	proxyTypes := []string{string(ProxyTypePod), string(ProxyTypeSQL)}
 
 	desiredProxyType := *flags.proxyType
-	if flags.sqlInstance != nil {
+	if *flags.sqlInstance != "" {
 		desiredProxyType = string(ProxyTypeSQL)
 	}
 	if desiredProxyType != "" {


### PR DESCRIPTION
Invalid "empty comparison" lead to a problem that CLOUD_SQL was always auto-selected.

Fix by comparing value, not a pointer